### PR TITLE
refactor(jni): unwrap useless unsafe blocks

### DIFF
--- a/emulator/src/linux/init_fun.rs
+++ b/emulator/src/linux/init_fun.rs
@@ -1,8 +1,8 @@
-use std::marker::PhantomData;
-use anyhow::anyhow;
-use log::{debug, error, info, warn};
 use crate::emulator::AndroidEmulator;
 use crate::pointer::VMPointer;
+use anyhow::anyhow;
+use log::error;
+use std::marker::PhantomData;
 
 #[derive(Clone)]
 pub(crate) enum InitFunction<'a, T: Clone> {
@@ -25,7 +25,11 @@ pub(crate) struct AbsoluteInitFunction<'a, T: Clone> {
 }
 
 impl<'a, T: Clone> AbsoluteInitFunction<'a, T> {
-    pub fn new(load_base: u64, lib_name: String, ptr: VMPointer<'a, T>) -> anyhow::Result<AbsoluteInitFunction<'a, T>> {
+    pub fn new(
+        load_base: u64,
+        lib_name: String,
+        ptr: VMPointer<'a, T>,
+    ) -> anyhow::Result<AbsoluteInitFunction<'a, T>> {
         let addr = ptr.read_u64_with_offset(0)?;
         Ok(Self {
             load_base,
@@ -48,7 +52,13 @@ impl<'a, T: Clone> InitFunctionTrait<'a, T> for AbsoluteInitFunction<'a, T> {
         }
 
         if address == 0 {
-            error!("[{}] CallInitFunction: address=0x{:X}, ptr={:X}, func={:X}", self.lib_name, address, self.ptr.addr, self.ptr.read_i64_with_offset(0)?);
+            error!(
+                "[{}] CallInitFunction: address=0x{:X}, ptr={:X}, func={:X}",
+                self.lib_name,
+                address,
+                self.ptr.addr,
+                self.ptr.read_i64_with_offset(0)?
+            );
             return Ok(address);
         }
 
@@ -65,9 +75,10 @@ impl<'a, T: Clone> InitFunctionTrait<'a, T> for AbsoluteInitFunction<'a, T> {
 #[derive(Clone)]
 pub(crate) struct LinuxInitFunction<'a, T: Clone> {
     pub load_base: u64,
+    #[allow(unused)]
     pub lib_name: String,
     pub addr: u64,
-    pd: PhantomData<&'a T>
+    pd: PhantomData<&'a T>,
 }
 
 impl<'a, T: Clone> LinuxInitFunction<'a, T> {

--- a/emulator/src/linux/structs.rs
+++ b/emulator/src/linux/structs.rs
@@ -1,21 +1,21 @@
-use std::{mem, ptr};
-use bitflags::bitflags;
 use crate::android::dvm::DalvikVM64;
 use crate::backend::Backend;
+use bitflags::bitflags;
+use std::{mem, ptr};
 
 #[repr(C)]
 #[derive(Default)]
 pub struct Stat64 {
     pub st_dev: i64,
     pub st_ino: i64,
-    pub st_mode: u32,//
-    pub st_nlink: i32,//
-    pub st_uid: i32,//
-    pub st_gid: i32,//
+    pub st_mode: u32,  //
+    pub st_nlink: i32, //
+    pub st_uid: i32,   //
+    pub st_gid: i32,   //
     pub st_rdev: i64,
     pub __pad1: i64,
     pub st_size: usize,
-    pub st_blksize: i32,//
+    pub st_blksize: i32, //
     pub __pad2: i32,
     pub st_blocks: i64,
 
@@ -24,7 +24,7 @@ pub struct Stat64 {
     pub st_ctime: Timespec,
 
     pub __unused4: u32,
-    pub __unused5: u32
+    pub __unused5: u32,
 }
 
 #[repr(C)]
@@ -41,7 +41,7 @@ pub struct Dirent {
     pub d_off: i64,
     pub d_reclen: u16,
     pub d_type: u8,
-    pub d_name: [u8; 256]
+    pub d_name: [u8; 256],
 }
 
 bitflags!(
@@ -104,14 +104,14 @@ bitflags! {
 #[derive(Clone)]
 pub struct Timeval {
     pub tv_sec: i64,
-    pub tv_usec: i64
+    pub tv_usec: i64,
 }
 
 #[repr(C)]
 #[derive(Clone)]
 pub struct Timezone {
     pub tz_minuteswest: i32,
-    pub tz_dsttime: i32
+    pub tz_dsttime: i32,
 }
 
 #[repr(C)]
@@ -120,7 +120,7 @@ pub struct DlInfo {
     pub dli_fname: u64,
     pub dli_fbase: u64,
     pub dli_sname: u64,
-    pub dli_saddr: u64
+    pub dli_saddr: u64,
 }
 
 #[repr(C)]
@@ -128,13 +128,10 @@ pub struct DlInfo {
 pub struct PropInfo {
     pub name: [u8; 32],
     pub serial: u32,
-    pub value: [u8; 92]
+    pub value: [u8; 92],
 }
 
-pub mod thread {
-
-
-}
+pub mod thread {}
 
 pub mod socket {
     use bitflags::bitflags;
@@ -188,7 +185,7 @@ pub mod socket {
         SMC = 43,
         XDP = 44,
         MCTP = 45,
-        MAX = 46
+        MAX = 46,
     }
 
     impl Pf {
@@ -241,7 +238,7 @@ pub mod socket {
                 44 => Pf::XDP,
                 45 => Pf::MCTP,
                 46 => Pf::MAX,
-                _ => Pf::UNSPEC
+                _ => Pf::UNSPEC,
             }
         }
     }
@@ -284,7 +281,7 @@ pub struct CVaList<'a, T: Clone> {
     pub vr_top: u64,
     pub gr_offs: i32,
     pub vr_offs: i32,
-    pub(crate) backend: Backend<'a, T>
+    pub(crate) backend: Backend<'a, T>,
 }
 
 impl<T: Clone> CVaList<'_, T> {
@@ -311,25 +308,25 @@ impl<T: Clone> CVaList<'_, T> {
 
 impl<D: Clone> CVaList<'_, D> {
     pub fn get<T: VaPrimitive<D>>(&mut self, dvm: &DalvikVM64<D>) -> T {
-        unsafe { T::get(self, dvm) }
+        T::get(self, dvm)
     }
 }
 
 pub trait VaPrimitive<T: Clone>: 'static {
     #[doc(hidden)]
-    unsafe fn get(_: &mut CVaList<T>, dvm: &DalvikVM64<T>) -> Self;
+    fn get(_: &mut CVaList<T>, dvm: &DalvikVM64<T>) -> Self;
 }
 
 macro_rules! impl_va_prim_gr {
     ($u: ty, $s: ty) => {
         impl<T: Clone> VaPrimitive<T> for $u {
-            unsafe fn get(list: &mut CVaList<T>, dvm: &DalvikVM64<T>) -> Self {
-                list.get_gr()
+            fn get(list: &mut CVaList<T>, _: &DalvikVM64<T>) -> Self {
+                unsafe { list.get_gr() }
             }
         }
         impl<T: Clone> VaPrimitive<T> for $s {
-            unsafe fn get(list: &mut CVaList<T>, dvm: &DalvikVM64<T>) -> Self {
-                mem::transmute(<$u>::get(list, dvm))
+            fn get(list: &mut CVaList<T>, dvm: &DalvikVM64<T>) -> Self {
+                unsafe { mem::transmute(<$u>::get(list, dvm)) }
             }
         }
     };
@@ -339,15 +336,15 @@ macro_rules! impl_va_prim_vr {
     ($($t:ty),+) => {
         $(
             impl<T: Clone> VaPrimitive<T> for $t {
-                unsafe fn get(list: &mut CVaList<T>, dvm: &DalvikVM64<T>) -> Self {
-                    list.get_vr()
+                fn get(list: &mut CVaList<T>, _: &DalvikVM64<T>) -> Self {
+                    unsafe { list.get_vr() }
                 }
             }
         )+
     };
 }
 
-impl_va_prim_gr!{ usize, isize }
-impl_va_prim_gr!{ u64, i64 }
-impl_va_prim_gr!{ u32, i32 }
-impl_va_prim_vr!{ f64, f32 }
+impl_va_prim_gr! { usize, isize }
+impl_va_prim_gr! { u64, i64 }
+impl_va_prim_gr! { u32, i32 }
+impl_va_prim_vr! { f64, f32 }


### PR DESCRIPTION
Hi there!

I'm glad to see someone trying to rewrite unidbg using Rust, it's a creation.

This is a simple commit, I just removed some unnecessary references and unsafe blocks.

I don't know if you mind if I make the following more work:

1. refactor the project structure to monorepo, i.e. migrate to crates, which is a common project structure used in the community, and I think this applies to rnidbg as well.
2. format the project code and even add a husky hook to make sure our code is compliant with the Rust programming paradigm.
3. enable clippy to do checks for the code to help us write more elegant code.
4. add continuous integration to the project for unit and integration testing, in fact not sure if it's my environment or not, I have an error in my main.rs.

Finally, thank you for your awesome work.
